### PR TITLE
Support for pod mount as storage

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -38,7 +38,7 @@ if [ "$NOMINATIM_MODE" == "CREATE" ]; then
     useradd -m -p password1234 nominatim
     sudo -u nominatim /srv/nominatim/build/utils/setup.php --osm-file $NOMINATIM_DATA_PATH/$NOMINATIM_DATA_LABEL.osm.pbf --all --threads $NOMINATIM_PG_THREADS
 
-    if [ [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ] || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
+    if ( [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ) || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
 
         # Stop PostgreSQL
         service postgresql stop
@@ -66,7 +66,7 @@ if [ "$NOMINATIM_MODE" == "CREATE" ]; then
 
 else
 
-    if [ [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ] || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
+    if ( [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ) || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
         # Copy the archive from storage
         mkdir -p $NOMINATIM_DATA_PATH
         if [ -n "$NOMINATIM_STORAGE_PATH" ] ; then

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -10,10 +10,15 @@ NOMINATIM_DATA_PATH=${NOMINATIM_DATA_PATH:="/srv/nominatim/data"}
 NOMINATIM_DATA_LABEL=${NOMINATIM_DATA_LABEL:="data"}
 NOMINATIM_PBF_URL=${NOMINATIM_PBF_URL:="http://download.geofabrik.de/asia/maldives-latest.osm.pbf"}
 NOMINATIM_POSTGRESQL_DATA_PATH=${NOMINATIM_POSTGRESQL_DATA_PATH:="/var/lib/postgresql/9.5/main"}
+
 # Google Storage variables
 NOMINATIM_SA_KEY_PATH=${NOMINATIM_SA_KEY_PATH:=""}
 NOMINATIM_PROJECT_ID=${NOMINATIM_PROJECT_ID:=""}
 NOMINATIM_GS_BUCKET=${NOMINATIM_GS_BUCKET:=""}
+
+# Generic storage path variables
+NOMINATIM_STORAGE_PATH=${NOMINATIM_STORAGE_PATH:=""}
+
 NOMINATIM_PG_THREADS=${NOMINATIM_PG_THREADS:=2}
 
 if [ "$NOMINATIM_MODE" == "CREATE" ]; then
@@ -33,7 +38,7 @@ if [ "$NOMINATIM_MODE" == "CREATE" ]; then
     useradd -m -p password1234 nominatim
     sudo -u nominatim /srv/nominatim/build/utils/setup.php --osm-file $NOMINATIM_DATA_PATH/$NOMINATIM_DATA_LABEL.osm.pbf --all --threads $NOMINATIM_PG_THREADS
 
-    if [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ]; then
+    if [ [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ] || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
 
         # Stop PostgreSQL
         service postgresql stop
@@ -41,31 +46,39 @@ if [ "$NOMINATIM_MODE" == "CREATE" ]; then
         # Archive PostgreSQL data
         tar cz $NOMINATIM_POSTGRESQL_DATA_PATH | split -b 1024MiB - $NOMINATIM_DATA_PATH/$NOMINATIM_DATA_LABEL.tgz_
 
-        # Activate the service account to access storage
-        gcloud auth activate-service-account --key-file $NOMINATIM_SA_KEY_PATH
-        # Set the Google Cloud project ID
-        gcloud config set project $NOMINATIM_PROJECT_ID
+        if [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
+            mkdir $NOMINATIM_STORAGE_PATH/$NOMINATIM_DATA_LABEL
 
-        # Copy the archive to storage
-        gsutil -m cp $NOMINATIM_DATA_PATH/*.tgz* $NOMINATIM_GS_BUCKET/$NOMINATIM_DATA_LABEL
+            cp $NOMINATIM_DATA_PATH/*.tgz* $NOMINATIM_STORAGE_PATH/$NOMINATIM_DATA_LABEL
+        else
+            # Activate the service account to access storage
+            gcloud auth activate-service-account --key-file $NOMINATIM_SA_KEY_PATH
+            # Set the Google Cloud project ID
+            gcloud config set project $NOMINATIM_PROJECT_ID
+
+            # Copy the archive to storage
+            gsutil -m cp $NOMINATIM_DATA_PATH/*.tgz* $NOMINATIM_GS_BUCKET/$NOMINATIM_DATA_LABEL
+        fi
 
         # Start PostgreSQL
         service postgresql start
-
     fi
 
 else
 
-    if [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ]; then
-
-        # Activate the service account to access storage
-        gcloud auth activate-service-account --key-file $NOMINATIM_SA_KEY_PATH
-        # Set the Google Cloud project ID
-        gcloud config set project $NOMINATIM_PROJECT_ID
-
+    if [ [ -n "$NOMINATIM_SA_KEY_PATH" ] && [ -n "$NOMINATIM_PROJECT_ID" ] && [ -n "$NOMINATIM_GS_BUCKET" ] ] || [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
         # Copy the archive from storage
         mkdir -p $NOMINATIM_DATA_PATH
-        gsutil -m cp $NOMINATIM_GS_BUCKET/$NOMINATIM_DATA_LABEL/*.tgz* $NOMINATIM_DATA_PATH
+        if [ -n "$NOMINATIM_STORAGE_PATH" ] ; then
+            cp $NOMINATIM_STORAGE_PATH/$NOMINATIM_DATA_LABEL/*.tgz* $NOMINATIM_DATA_PATH
+        else
+            # Activate the service account to access storage
+            gcloud auth activate-service-account --key-file $NOMINATIM_SA_KEY_PATH
+            # Set the Google Cloud project ID
+            gcloud config set project $NOMINATIM_PROJECT_ID
+
+            gsutil -m cp $NOMINATIM_GS_BUCKET/$NOMINATIM_DATA_LABEL/*.tgz* $NOMINATIM_DATA_PATH
+        fi
 
         # Remove any files present in the target directory
         rm -rf ${NOMINATIM_POSTGRESQL_DATA_PATH:?}/*

--- a/kubernetes/azure-nominatim-canary.yaml
+++ b/kubernetes/azure-nominatim-canary.yaml
@@ -1,0 +1,56 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nominatim
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: nominatim
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nominatim-canary
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nominatim
+  template:
+    metadata:
+      labels:
+        app: nominatim
+        track: canary
+    spec:
+      containers:
+      - name: nominatim-k8s
+        image: peterevans/nominatim-k8s:latest
+        env:
+        - name: NOMINATIM_MODE
+          value: CREATE
+        - name: NOMINATIM_PBF_URL
+          value: "http://download.geofabrik.de/asia/maldives-latest.osm.pbf"
+        - name: NOMINATIM_DATA_LABEL
+          value: maldives-20161213
+        - name: NOMINATIM_STORAGE_PATH
+          value: "/mnt/azure"
+        volumeMounts:
+        - name: azure
+          mountPath: /mnt/azure
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /search
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+      volumes:
+      - name: azure
+        azureFile:
+          secretName: azure-storage-secret
+          shareName: azure
+          readOnly: false

--- a/kubernetes/azure-nominatim-canary.yaml
+++ b/kubernetes/azure-nominatim-canary.yaml
@@ -19,6 +19,7 @@ spec:
   selector:
     matchLabels:
       app: nominatim
+      track: canary
   template:
     metadata:
       labels:

--- a/kubernetes/azure-nominatim.yaml
+++ b/kubernetes/azure-nominatim.yaml
@@ -21,6 +21,10 @@ spec:
       app: nominatim
       track: stable
   template:
+      metadata:
+      labels:
+        app: nominatim
+        track: stable
     spec:
       containers:
       - name: nominatim-k8s

--- a/kubernetes/azure-nominatim.yaml
+++ b/kubernetes/azure-nominatim.yaml
@@ -1,0 +1,51 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: nominatim
+spec:
+  ports:
+  - port: 80
+    targetPort: 8080
+    protocol: TCP
+  selector:
+    app: nominatim
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nominatim
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: nominatim
+      track: stable
+  template:
+    spec:
+      containers:
+      - name: nominatim-k8s
+        image: peterevans/nominatim-k8s:latest
+        env:
+        - name: NOMINATIM_MODE
+          value: RESTORE
+        - name: NOMINATIM_DATA_LABEL
+          value: maldives-20161213
+        - name: NOMINATIM_STORAGE_PATH
+          value: "/mnt/azure"
+        volumeMounts:
+        - name: azure
+          mountPath: /mnt/azure
+        ports:
+        - containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /search
+            port: 8080
+          initialDelaySeconds: 30
+          timeoutSeconds: 1
+      volumes:
+      - name: azure
+        azureFile:
+          secretName: azure-storage-secret
+          shareName: azure
+          readOnly: false

--- a/kubernetes/azure-storage-secret.yaml
+++ b/kubernetes/azure-storage-secret.yaml
@@ -1,0 +1,7 @@
+# Please have a look at https://docs.microsoft.com/en-us/azure/aks/azure-files-volume
+apiVersion: v1
+data:
+  azurestorageaccountkey: <base64 encoded value here>
+  azurestorageaccountname: <base64 encoded value here>
+kind: Secret
+type: Opaque


### PR DESCRIPTION
This will make it easier to use this on other cloud environments, as long at they support mounting a file storage on the Pod.
In our case, this is confirmed working with Azure (examples provided).

Should be 100% compatible with existing setups.